### PR TITLE
migration filename pattern update: file contains letters and numbers

### DIFF
--- a/copy_this/core/oxmigrationquery.php
+++ b/copy_this/core/oxmigrationquery.php
@@ -39,7 +39,7 @@ abstract class oxMigrationQuery
      * First match: timestamp
      * Second match: class name without "migration" appended
      */
-    const REGEXP_FILE = '/(\d{14})_([a-zA-Z]+)\.php$/';
+    const REGEXP_FILE = '/(\d{14})_([a-zA-Z0-9]+)\.php$/';
 
     /**
      * @var string Timestamp


### PR DESCRIPTION
migration filename should contain not only letters, but numbers also: e.g. 20141010104441_oxobject2something.php
