### PR TITLE
migration filename pattern update

### DIFF
--- a/copy_this/core/oxmigrationquery.php
+++ b/copy_this/core/oxmigrationquery.php
@@ -39,7 +39,7 @@ abstract class oxMigrationQuery
      * First match: timestamp
      * Second match: class name without "migration" appended
      */
-    const REGEXP_FILE = '/(\d{14})_([a-zA-Z]+)\.php$/';
+    const REGEXP_FILE = '/(\d{14})_([a-zA-Z][a-zA-Z0-9]+)\.php$/';
 
     /**
      * @var string Timestamp


### PR DESCRIPTION
once again. migration filename should contain not only letters, but numbers, except first class name character is not number, but letter i.e.
`20141002104848_object2something.php` filename `Object2Something` class name
