### PR TITLE
configuration object should be set for every single subshop

### DIFF
--- a/copy_this/core/oxmodulestatefixer.php
+++ b/copy_this/core/oxmodulestatefixer.php
@@ -23,7 +23,7 @@ class oxModuleStateFixer extends oxModuleInstaller
      */
     public function fix(oxModule $oModule, oxConfig $oConfig = null)
     {
-        if ($oConfig === null) {
+        if ($oConfig !== null) {
             $this->setConfig($oConfig);
         }
 


### PR DESCRIPTION
Bugfix: the command fix:states updates blocks in the table oxtplblocks only for the main shop, not for subshops.