### PR TITLE
oxid console v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 To get the diff for a specific change, go to https://github.com/EllisV/oxid-console/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/EllisV/oxid-console/compare/v1.2.1...v1.2.2
 
+* 1.2.3 (2015-11-23)
+    * oxoutput object for migrations
+      clearcache command with support for backendcaches (e.g. memcached) 
+      clearcache command more verbose about directory
+      bump version number
+      oxdbmigrationquery.php as base for database migrations
+      fixstates command can now fix new modules
+
 * 1.2.2 (2015-06-07)
     * (c49ecb0) Bugfix for fix:states not working for all shops
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 To get the diff for a specific change, go to https://github.com/EllisV/oxid-console/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/EllisV/oxid-console/compare/v1.2.1...v1.2.2
 
+* 1.2.4 (2015-11-23)
+    * new module:activate command
+
 * 1.2.3 (2015-11-23)
     * oxoutput object for migrations
       clearcache command with support for backendcaches (e.g. memcached) 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ By default there are following commands included:
 * `g:module` - Generate new module scaffold
 * `list` - *(default)* List of all available commands
 * `migrate` - Run migration scripts
+* `module:activate` - Activate module in shop
+
 
 This OXID Console repository has **Migration Handler** and **Module State Fixer** included.
 

--- a/copy_this/application/commands/cacheclearcommand.php
+++ b/copy_this/application/commands/cacheclearcommand.php
@@ -48,12 +48,20 @@ class CacheClearCommand extends oxConsoleCommand
     public function execute(oxIOutput $oOutput)
     {
         $oInput = $this->getInput();
+
+        $oOutput->writeLn('Clearing OXID db and backend cache..');
+        /** @var oxCache $oCache */
+        $oCache = oxNew('oxcache');
+        $oCache->reset(false);
+        $oOutput->writeLn('Oxid Cache cleared successfully');
+
+
         $sTmpDir = $this->_appendDirectorySeparator(oxRegistry::getConfig()->getConfigParam('sCompileDir'));
         if (!is_dir($sTmpDir)) {
             $oOutput->writeLn('Seems that compile directory does not exist');
         }
 
-        $oOutput->writeLn('Clearing OXID cache...');
+        $oOutput->writeLn("Clearing OXID File cache ($sTmpDir)...");
 
         $this->_clearDirectory($sTmpDir . 'smarty');
         if (!$oInput->hasOption(array('s', 'smarty'))) {
@@ -61,7 +69,8 @@ class CacheClearCommand extends oxConsoleCommand
             $this->_clearDirectory($sTmpDir, array('.htaccess', 'smarty'));
         }
 
-        $oOutput->writeLn('Cache cleared successfully');
+        $oOutput->writeLn('File Cache cleared successfully');
+
     }
 
     /**

--- a/copy_this/application/commands/fixstatescommand.php
+++ b/copy_this/application/commands/fixstatescommand.php
@@ -75,7 +75,7 @@ class FixStatesCommand extends oxConsoleCommand
 
             foreach ($aModuleIds as $sModuleId) {
                 if (!$oModule->load($sModuleId)) {
-                    $oDebugOutput->writeLn("[DEBUG] {$sModuleId} does not exist - skipping");
+                    $oDebugOutput->writeLn("[DEBUG] {$sModuleId} can not be loaded - skipping");
                     continue;
                 }
 
@@ -174,6 +174,12 @@ class FixStatesCommand extends oxConsoleCommand
      */
     protected function _getAvailableModuleIds()
     {
+        // reloading modules from path because else new modules are not not listed within aModulePaths
+        $oxModuleList = oxNew('oxModuleList');
+        $oxModuleList->getModulesFromDir(oxRegistry::getConfig()->getModulesDir());
+        $aModules = $oxModuleList->getList();
+        // end reloading modules (the new modules are now listed in aModulePaths (for shop 1 only)
+
         if ($this->_aAvailableModuleIds === null) {
             $oConfig = oxRegistry::getConfig();
             $this->_aAvailableModuleIds = array_keys($oConfig->getConfigParam('aModulePaths'));

--- a/copy_this/application/commands/moduleactivatecommand.php
+++ b/copy_this/application/commands/moduleactivatecommand.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is part of OXID Console.
+ *
+ * OXID Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OXID Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OXID Console.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author        OXID Professional services
+ * @link          http://www.oxid-esales.com
+ * @copyright (C) OXID eSales AG 2003-2015
+ */
+
+
+/**
+ * Class OxpsConfigImportCommandBase
+ */
+class ModuleActivateCommand extends oxConsoleCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('module:activate');
+        $this->setDescription('Activate module in shop');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function help(oxIOutput $oOutput)
+    {
+        $oOutput->writeLn('Usage: module:activate [options] moduleid');
+        $oOutput->writeLn();
+        $oOutput->writeLn('This command imports shop config');
+        $oOutput->writeLn();
+        $oOutput->writeLn('Available options:');
+        $oOutput->writeLn('  -n, --no-debug     No debug output');
+        $oOutput->writeLn('  -s, --shop         Shop');
+    }
+
+    /**
+     * Execute current command
+     *
+     * @param oxIOutput $oOutput
+     */
+    public function execute(oxIOutput $oOutput)
+    {
+        $oInput = $this->getInput();
+        /** @var oxModuleStateFixer $oModuleStateFixer */
+        $oModuleInstaller = oxRegistry::get('oxModuleInstaller');
+
+        $sModuleId = $oInput->getArgument(1);
+
+        if (!$sModuleId) {
+            $this->help($oOutput);
+
+            return;
+        }
+
+        if ($oInput->hasOption(array('s', 'shop'))) {
+            $sShopId = $oInput->getOption(array('s', 'shop'));
+            $oConfig = oxSpecificShopConfig::get($sShopId);
+            $oModuleInstaller->setConfig($oConfig);
+        }
+
+        $oxModuleList = oxNew('oxModuleList');
+        $oxModuleList->getModulesFromDir(oxRegistry::getConfig()->getModulesDir());
+        $aModules = $oxModuleList->getList();
+
+        $oModule = $aModules[$sModuleId];
+        if ($oModule == null) {
+            $oOutput->writeLn("$sModuleId not found. choose from:");
+            $oOutput->writeLn(join("\n", array_keys($aModules)));
+            return;
+        }
+        $oModuleInstaller->activate($oModule);
+    }
+
+}

--- a/copy_this/application/commands/moduleactivatecommand.php
+++ b/copy_this/application/commands/moduleactivatecommand.php
@@ -22,7 +22,7 @@
 
 
 /**
- * Class OxpsConfigImportCommandBase
+ * Class ModuleActivateCommand
  */
 class ModuleActivateCommand extends oxConsoleCommand
 {
@@ -58,8 +58,6 @@ class ModuleActivateCommand extends oxConsoleCommand
     public function execute(oxIOutput $oOutput)
     {
         $oInput = $this->getInput();
-        /** @var oxModuleStateFixer $oModuleStateFixer */
-        $oModuleInstaller = oxRegistry::get('oxModuleInstaller');
 
         $sModuleId = $oInput->getArgument(1);
 
@@ -71,6 +69,18 @@ class ModuleActivateCommand extends oxConsoleCommand
 
         if ($oInput->hasOption(array('s', 'shop'))) {
             $sShopId = $oInput->getOption(array('s', 'shop'));
+        }
+
+        $this->activateModule($sModuleId, $sShopId, $oOutput);
+    }
+
+
+    public function activateModule($sModuleId, $sShopId, $oOutput)
+    {
+        /** @var oxModuleInstaller $oModuleInstaller */
+        $oModuleInstaller = oxRegistry::get('oxModuleInstaller');
+
+        if ($sShopId) {
             $oConfig = oxSpecificShopConfig::get($sShopId);
             $oModuleInstaller->setConfig($oConfig);
         }
@@ -79,13 +89,20 @@ class ModuleActivateCommand extends oxConsoleCommand
         $oxModuleList->getModulesFromDir(oxRegistry::getConfig()->getModulesDir());
         $aModules = $oxModuleList->getList();
 
+        /** @var oxModule $oModule */
+
         $oModule = $aModules[$sModuleId];
         if ($oModule == null) {
             $oOutput->writeLn("$sModuleId not found. choose from:");
             $oOutput->writeLn(join("\n", array_keys($aModules)));
+
             return;
         }
-        $oModuleInstaller->activate($oModule);
-    }
 
+        if ($oModule->isActive()) {
+            $oOutput->writeLn("$sModuleId already active");
+        } else {
+            $oModuleInstaller->activate($oModule);
+        }
+    }
 }

--- a/copy_this/core/oxconsoleapplication.php
+++ b/copy_this/core/oxconsoleapplication.php
@@ -28,7 +28,7 @@ class oxConsoleApplication
     /**
      * OXID Console application version
      */
-    const VERSION = 'v1.2.3';
+    const VERSION = 'v1.2.4';
 
     /**
      * @var oxConsoleCommand[] Available commands in console

--- a/copy_this/core/oxconsoleapplication.php
+++ b/copy_this/core/oxconsoleapplication.php
@@ -28,7 +28,7 @@ class oxConsoleApplication
     /**
      * OXID Console application version
      */
-    const VERSION = 'v1.2.2';
+    const VERSION = 'v1.2.3';
 
     /**
      * @var oxConsoleCommand[] Available commands in console

--- a/copy_this/core/oxconsoleapplication.php
+++ b/copy_this/core/oxconsoleapplication.php
@@ -28,7 +28,7 @@ class oxConsoleApplication
     /**
      * OXID Console application version
      */
-    const VERSION = 'v1.2.4';
+    const VERSION = 'v1.2.5';
 
     /**
      * @var oxConsoleCommand[] Available commands in console

--- a/copy_this/core/oxdbmigrationquery.php
+++ b/copy_this/core/oxdbmigrationquery.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ * This file is part of the OXID Console package.
+ *
+ * (c) Eligijus Vitkauskas <eligijusvitkauskas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Migration query class. All migration queries must extend this class
+ *
+ * Migration class filename must match timestamp_classname.php format
+ */
+abstract class oxDbMigrationQuery extends oxMigrationQuery
+{
+
+    /**
+     * This method in the subclass must return the list of columns that should be added or removed
+     * @return array
+     */
+    abstract protected function getTables();
+
+    /* TODO add support for indexes
+    protected function getIndexes()
+    {
+        return [];
+    }
+    */
+
+    /**
+     * @var string $sSql the sql string that's being generated
+     */
+    protected $sSql = "";
+
+    /**
+     * @var array $aSql array of sql parts to be combined
+     */
+    protected $aSql;
+
+    /**
+     * @var bool $blUp up or down migration
+     */
+    protected $blUp = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function up()
+    {
+        $this->alterTables();
+    }
+
+    /**
+     * iterates over the table definitions and build and execute the sql statements
+     */
+    protected function alterTables()
+    {
+        $aTables = $this->getTables();
+        $this->sSql = "";
+        foreach ($aTables as $sTable => $aTableDef) {
+            $this->alterColumns($sTable, $aTableDef['columns']);
+            if ($this->sSql != "") {
+                $this->sSql = "ALTER TABLE $sTable " . $this->sSql;
+            }
+            $this->executeSqlStm();
+        }
+    }
+
+    /**
+     * execute a sql statement and rests the sql string
+     */
+    protected function executeSqlStm()
+    {
+        $oDb = oxDb::getDb();
+        $this->_oOutput->writeLn($this->sSql);
+        $oDb->execute($this->sSql);
+        $this->sSql = "";
+    }
+
+    /**
+     * builds the sql to create or drom columns for a table
+     * @param string $sTable the name of the table
+     * @param array $aColumns the array of columns
+     */
+    protected function alterColumns($sTable, $aColumns)
+    {
+        foreach ($aColumns as $aColumnInfo) {
+            $this->alterColumn($sTable, $aColumnInfo[0], $aColumnInfo[1]);
+        }
+        if($this->aSql) {
+            $this->sSql = join(',', $this->aSql);
+        }
+    }
+
+    /**
+     * builds the sql to create or drom columns for a table
+     * @param string $sTable the name of the table
+     * @param string $sColumn the name of the column
+     * @param array $sColumnDef the column definition
+     */
+    protected function alterColumn($sTable, $sColumn, $sColumnDef)
+    {
+
+        $blExists = $this->_columnExists($sTable, $sColumn);
+        if ($this->blUp) {
+            if (!$blExists) {
+                $this->aSql[] = "ADD COLUMN `$sColumn` $sColumnDef";
+            }
+        } else {
+            if ($blExists) {
+                $this->aSql[] = "DROP COLUMN `$sColumn`";
+            }
+        }
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function down()
+    {
+        $this->blUp = false;
+        $this->alterTables();
+    }
+}

--- a/copy_this/core/oxmigrationhandler.php
+++ b/copy_this/core/oxmigrationhandler.php
@@ -92,6 +92,7 @@ class oxMigrationHandler
         }
 
         foreach ($this->getQueries() as $oQuery) {
+            $oQuery->setOutput($oOutput);
             $oQuery->getTimestamp() < $sTimestamp
                 ? $this->_goUp($oQuery, $oOutput)
                 : $this->_goDown($oQuery, $oOutput);

--- a/copy_this/core/oxmigrationquery.php
+++ b/copy_this/core/oxmigrationquery.php
@@ -46,6 +46,13 @@ abstract class oxMigrationQuery
     protected $_sClassName;
 
     /**
+     * @var oxIOutput output object
+     */
+    protected $_oOutput;
+
+
+
+    /**
      * Constructor
      *
      * Extracts timestamp from filename of migration query
@@ -66,8 +73,13 @@ abstract class oxMigrationQuery
         $this->setFilename($sFilename);
         $this->setTimestamp($aMatches[1]);
         $this->setClassName($aMatches[2] . 'migration');
-
+        $this->setOutput(oxNew('oxNullOutput'));
         $this->_validateClassName();
+    }
+
+    public function setOutput(oxIOutput $oOutput)
+    {
+        $this->_oOutput = $oOutput;
     }
 
     /**


### PR DESCRIPTION
+ oxoutput object for migrations
+ clearcache command with support for backendcaches (e.g. memcached)
+ clearcache command more verbose about directory
+ bump version number
+ oxdbmigrationquery.php as base for database migrations
+ fixstates command can now fix new modules
