### PR TITLE
add output object to migrations

### DIFF
--- a/copy_this/core/oxmigrationhandler.php
+++ b/copy_this/core/oxmigrationhandler.php
@@ -92,6 +92,7 @@ class oxMigrationHandler
         }
 
         foreach ($this->getQueries() as $oQuery) {
+            $oQuery->setOutput($oOutput);
             $oQuery->getTimestamp() < $sTimestamp
                 ? $this->_goUp($oQuery, $oOutput)
                 : $this->_goDown($oQuery, $oOutput);

--- a/copy_this/core/oxmigrationquery.php
+++ b/copy_this/core/oxmigrationquery.php
@@ -46,6 +46,13 @@ abstract class oxMigrationQuery
     protected $_sClassName;
 
     /**
+     * @var oxIOutput output object
+     */
+    protected $_oOutput;
+
+
+
+    /**
      * Constructor
      *
      * Extracts timestamp from filename of migration query
@@ -66,8 +73,13 @@ abstract class oxMigrationQuery
         $this->setFilename($sFilename);
         $this->setTimestamp($aMatches[1]);
         $this->setClassName($aMatches[2] . 'migration');
-
+        $this->setOutput(oxNew('oxNullOutput'));
         $this->_validateClassName();
+    }
+
+    public function setOutput(oxIOutput $oOutput)
+    {
+        $this->_oOutput = $oOutput;
     }
 
     /**


### PR DESCRIPTION
this makes it possible to use the output object in migrations