### PR TITLE
support cammelcase filenames for commands

### DIFF
--- a/copy_this/core/oxconsoleapplication.php
+++ b/copy_this/core/oxconsoleapplication.php
@@ -234,7 +234,7 @@ class oxConsoleApplication
         $oDirectory = new RecursiveDirectoryIterator($sDirectory);
         $oFlattened = new RecursiveIteratorIterator($oDirectory);
 
-        $aFiles = new RegexIterator($oFlattened, '/.*command\.php$/');
+        $aFiles = new RegexIterator($oFlattened, '/.*command\.php$/i');
         foreach ($aFiles as $sFilePath) {
             require_once $sFilePath;
 


### PR DESCRIPTION
this commit adds support for camel case in filenames for new commands.
e.G. 
```
commands/MyCommand.php 
```
will be found.