### PR TITLE
Fixed Bug which leads to use of wrong module settings on config key duplicates

### DIFF
--- a/copy_this/application/commands/fixstatescommand.php
+++ b/copy_this/application/commands/fixstatescommand.php
@@ -80,6 +80,9 @@ class FixStatesCommand extends oxConsoleCommand
                 }
 
                 $oDebugOutput->writeLn("[DEBUG] Fixing {$sModuleId} module");
+
+                $oConfig->fixWrongConfigParams($sModuleId);
+
                 $oModuleStateFixer->fix($oModule, $oConfig);
             }
 


### PR DESCRIPTION
I fixed a bug which leaded to use of wrong module settings in the fix states command.

The problem was:
The oxconfig object initializes the module settings in a global array called _aConfigParams. In this array is no mapping to the modules. If the case is present that two module have keys with the exact same name then it happens that one of the modules get the setting of the other module on fix states.

With my changes this bug is resolved.

I did the following:

- On init all module settings are loaded in an array called aModuleSettings.
- This array contains two levels: 1) the modules 2) the settings per module
- Now within each modules iteration in the fixstatescommand the method fixWrongConfigParams on the config object is called.
- This method puts the correct settings for this module in the array aModuleSettings.
- Now the module gets the correct settings on fix states and not random ones.

To be honest: This leads to a bad design of the oxconfig object structure because they concat all the params in array without an sublevel of modules.