### PR TITLE
added `-s` or `--skip-settings` flag to `fix:states` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ To get the diff for a specific change, go to https://github.com/EllisV/oxid-cons
 To get the diff between two versions, go to https://github.com/EllisV/oxid-console/compare/v1.2.4...v1.2.5
 
 * 1.2.6 (not released yet)
+    * added `-s` or `--skip-settings` flag to `fix:states` command
     * (9a94f32) Support camel cased command file names
 
 * 1.2.5 (2016-11-25)

--- a/copy_this/application/commands/fixstatescommand.php
+++ b/copy_this/application/commands/fixstatescommand.php
@@ -39,10 +39,11 @@ class FixStatesCommand extends oxConsoleCommand
         $oOutput->writeLn('This command fixes information stored in database of modules');
         $oOutput->writeln();
         $oOutput->writeLn('Available options:');
-        $oOutput->writeLn('  -a, --all         Passes all modules');
-        $oOutput->writeLn('  -b, --base-shop   Fix only on base shop');
-        $oOutput->writeLn('  --shop=<shop_id>  Specifies in which shop to fix states');
-        $oOutput->writeLn('  -n, --no-debug    No debug output');
+        $oOutput->writeLn('  -a, --all              Passes all modules');
+        $oOutput->writeLn('  -b, --base-shop        Fix only on base shop');
+        $oOutput->writeLn('  --shop=<shop_id>       Specifies in which shop to fix states');
+        $oOutput->writeLn('  -n, --no-debug         No debug output');
+        $oOutput->writeLn('  -s, --skip-settings    Don\'t reset module settings');
     }
 
     /**
@@ -54,6 +55,8 @@ class FixStatesCommand extends oxConsoleCommand
         $oDebugOutput = $oInput->hasOption(array('n', 'no-debug'))
             ? oxNew('oxNullOutput')
             : $oOutput;
+
+        $resetSettings = !$oInput->hasOption(array('s', 'skip-settings'));
 
         try {
             $aModuleIds = $this->_parseModuleIds();
@@ -80,7 +83,7 @@ class FixStatesCommand extends oxConsoleCommand
                 }
 
                 $oDebugOutput->writeLn("[DEBUG] Fixing {$sModuleId} module");
-                $oModuleStateFixer->fix($oModule, $oConfig);
+                $oModuleStateFixer->fix($oModule, $oConfig, $resetSettings);
             }
 
             $oDebugOutput->writeLn();

--- a/copy_this/core/oxmodulestatefixer.php
+++ b/copy_this/core/oxmodulestatefixer.php
@@ -21,7 +21,7 @@ class oxModuleStateFixer extends oxModuleInstaller
      * @param oxModule      $oModule
      * @param oxConfig|null $oConfig If not passed uses default base shop config
      */
-    public function fix(oxModule $oModule, oxConfig $oConfig = null)
+    public function fix(oxModule $oModule, oxConfig $oConfig = null, $resetSettings = true)
     {
         if ($oConfig !== null) {
             $this->setConfig($oConfig);
@@ -40,7 +40,9 @@ class oxModuleStateFixer extends oxModuleInstaller
         $this->_addTemplateBlocks($oModule->getInfo("blocks"), $sModuleId);
         $this->_addModuleFiles($oModule->getInfo("files"), $sModuleId);
         $this->_addTemplateFiles($oModule->getInfo("templates"), $sModuleId);
-        $this->_addModuleSettings($oModule->getInfo("settings"), $sModuleId);
+        if ($resetSettings) {
+            $this->_addModuleSettings($oModule->getInfo("settings"), $sModuleId);
+        }
         $this->_addModuleVersion($oModule->getInfo("version"), $sModuleId);
         $this->_addModuleEvents($oModule->getInfo("events"), $sModuleId);
 


### PR DESCRIPTION
This Pull Request adds a new flag to the `fix:states` command, which skips the settings part in the `fix()` method. The statefixer removes settings, which are not in the metadata.php.

![image](https://cloud.githubusercontent.com/assets/1001186/23749303/d870eb16-04c7-11e7-9632-a5685d655890.png)

see also jkrug/TOXID-cURL#42