### PR TITLE
set php_handling to SMARTY_PHP_PASSTHRU in generate-commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: precise
+
 cache:
   directories:
     - vendor

--- a/copy_this/application/commands/generatemigrationcommand.php
+++ b/copy_this/application/commands/generatemigrationcommand.php
@@ -65,6 +65,7 @@ class GenerateMigrationCommand extends oxConsoleCommand
 
         /** @var Smarty $oSmarty */
         $oSmarty = oxRegistry::get('oxUtilsView')->getSmarty();
+        $oSmarty->php_handling = SMARTY_PHP_PASSTHRU;
         $oSmarty->assign('sMigrationName', $sMigrationName);
         $sContent = $oSmarty->fetch($sTemplatePath);
 

--- a/copy_this/application/commands/generatemodulecommand.php
+++ b/copy_this/application/commands/generatemodulecommand.php
@@ -39,6 +39,7 @@ class GenerateModuleCommand extends oxConsoleCommand
         $this->setDescription('Generate new module scaffold');
 
         $this->_oSmarty = oxRegistry::get('oxUtilsView')->getSmarty();
+        $this->_oSmarty->php_handling = SMARTY_PHP_PASSTHRU;
         $this->_sModuleDir = OX_BASE_PATH . 'modules' . DIRECTORY_SEPARATOR;
         $this->_sTemplatesDir = __DIR__ . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR
             . 'module' . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
From `Smarty.class.php`:
```
    /**
     * This determines how Smarty handles "<?php ... ?>" tags in templates.
     * possible values:
     * <ul>
     *  <li>SMARTY_PHP_PASSTHRU -> print tags as plain text</li>
     *  <li>SMARTY_PHP_QUOTE    -> escape tags as entities</li>
     *  <li>SMARTY_PHP_REMOVE   -> remove php tags</li>
     *  <li>SMARTY_PHP_ALLOW    -> execute php tags</li>
     * </ul>
     *
     * @var integer
     */
    var $php_handling    =  SMARTY_PHP_PASSTHRU;
```